### PR TITLE
Add OpenShift support with ServiceAccount and Security Context

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -49,3 +49,14 @@ Selector labels
 app.kubernetes.io/name: {{ include "modsecurity-crs-proxy.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "modsecurity-crs-proxy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "modsecurity-crs-proxy.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -32,6 +32,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "modsecurity-crs-proxy.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if .Values.geoip.enabled }}

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "modsecurity-crs-proxy.serviceAccountName" . }}
+  labels:
+    {{- include "modsecurity-crs-proxy.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -14,6 +14,18 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+  # NOTE: For OpenShift deployments, see README.md section "OpenShift Deployment"
+
 # IMPORTANT: set your backend service where the traffic should be forwarded to
 backend: "http://my-app.svc.cluster.local:80"
 
@@ -57,16 +69,19 @@ annotations: {}
 podAnnotations: {}
 podLabels: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  runAsUser: 999
+  runAsGroup: 999
+  fsGroup: 999
+  runAsNonRoot: true
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  # readOnlyRootFilesystem must be false as Apache needs write access for logs/temp
+  readOnlyRootFilesystem: false
 
 podDisruptionBudget:
   enabled: false


### PR DESCRIPTION
This PR adds native OpenShift support to the Helm chart, resolving issue #10.

   ## Changes
   - **ServiceAccount**: Added template with configurable options (create, name, annotations, automount)
   - **Security Context**: Configured pod and container security contexts for non-root execution as UID 999 (httpd user)
   - **Security Hardening**:
     - Drop all Linux capabilities
     - Prevent privilege escalation
     - Enforce non-root execution
   - **Documentation**: Added comprehensive OpenShift deployment section to README.md with SCC binding instructions
   - **Deployment Template**: Updated to reference the ServiceAccount

   ## OpenShift Compatibility
   The chart now automatically creates a ServiceAccount and configures all security contexts to match the `owasp/modsecurity-crs` container requirements (runs as httpd user, UID 999).

   Users only need to bind the ServiceAccount to a compatible SCC (e.g., `nonroot-v2`) after installation:
   ```bash
   oc adm policy add-scc-to-user nonroot-v2 -z <serviceaccount-name> -n <namespace>
   ```